### PR TITLE
feat(pricing): add new GPT-4.1 models and update pricing tiers

### DIFF
--- a/pricing.json
+++ b/pricing.json
@@ -3,7 +3,25 @@
     "o4-mini": {
       "input": 1.1,
       "cachedInput": 0.275,
-      "output": 4.4,
+      "output": 4.4
+    },
+    "gpt-4.1": {
+      "input": 2.0,
+      "cachedInput": 0.5,
+      "output": 8.0,
+      "batchDiscount": 0.5
+    },
+    "gpt-4.1-mini": {
+      "input": 0.4,
+      "cachedInput": 0.1,
+      "output": 1.6,
+      "batchDiscount": 0.5
+    },
+    "gpt-4.1-nano": {
+      "input": 0.1,
+      "cachedInput": 0.025,
+      "output": 0.4,
+      "batchDiscount": 0.5
     },
     "gpt-4.5-preview": {
       "input": 75,
@@ -47,6 +65,15 @@
       "output": 60,
       "batchDiscount": 0.5
     },
+    "o1-pro": {
+      "input": 150,
+      "output": 600
+    },
+    "o3": {
+      "input": 10,
+      "cachedInput": 2.5,
+      "output": 40
+    },
     "o3-mini": {
       "input": 1.1,
       "cachedInput": 0.55,
@@ -54,9 +81,15 @@
       "batchDiscount": 0.5
     },
     "o1-mini": {
-      "input": 3,
-      "output": 12,
+      "input": 1.1,
+      "cachedInput": 0.55,
+      "output": 4.4,
       "batchDiscount": 0.5
+    },
+    "codex-mini-latest": {
+      "input": 1.5,
+      "cachedInput": 0.375,
+      "output": 6.0
     },
     "gpt-4o-mini-search-preview": {
       "input": 0.15,
@@ -70,6 +103,10 @@
       "input": 3,
       "output": 12,
       "batchDiscount": 0.5
+    },
+    "gpt-image-1": {
+      "input": 5,
+      "cachedInput": 1.25
     },
     "chatgpt-4o-latest": {
       "input": 5,
@@ -108,7 +145,19 @@
       "output": 0.4
     }
   },
-  "audio_tokens": {
+  "flex-processing": {
+    "o3": {
+      "input": 5,
+      "cachedInput": 1.25,
+      "output": 20
+    },
+    "o4-mini": {
+      "input": 0.55,
+      "cachedInput": 0.138,
+      "output": 2.2
+    }
+  },
+  "audio-tokens": {
     "gpt-4o-audio-preview": {
       "input": 40,
       "output": 80
@@ -128,7 +177,44 @@
       "output": 20
     }
   },
+  "image-tokens": {
+    "gpt-image-1": {
+      "input": 10,
+      "cachedInput": 2.5,
+      "output": 40
+    }
+  },
   "fine-tuning": {
+    "o4-mini-2025-04-16": {
+      "training": 100,
+      "input": 4,
+      "cachedInput": 1,
+      "output": 16
+    },
+    "o4-mini-2025-04-16-data-sharing": {
+      "training": 100,
+      "input": 2,
+      "cachedInput": 0.5,
+      "output": 8
+    },
+    "gpt-4.1-2025-04-14": {
+      "training": 25,
+      "input": 3,
+      "cachedInput": 0.75,
+      "output": 12
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "training": 5,
+      "input": 0.8,
+      "cachedInput": 0.2,
+      "output": 3.2
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "training": 1.5,
+      "input": 0.2,
+      "cachedInput": 0.05,
+      "output": 0.8
+    },
     "gpt-4o-2024-08-06": {
       "training": 25,
       "input": 3.75,
@@ -168,6 +254,11 @@
       "cost": 2.5
     },
     "web-search": {
+      "gpt-4.1": {
+        "low": 30,
+        "medium": 35,
+        "high": 50
+      },
       "gpt-4o": {
         "low": 30,
         "medium": 35,
@@ -178,15 +269,52 @@
         "medium": 35,
         "high": 50
       },
+      "gpt-4.1-mini": {
+        "low": 25,
+        "medium": 27.5,
+        "high": 30
+      },
       "gpt-4o-mini": {
-        "low": 10,
-        "medium": 12,
-        "high": 15
+        "low": 25,
+        "medium": 27.5,
+        "high": 30
       },
       "gpt-4o-mini-search-preview": {
-        "low": 10,
-        "medium": 12,
-        "high": 15
+        "low": 25,
+        "medium": 27.5,
+        "high": 30
+      }
+    }
+  },
+  "transcription_speech": {
+    "text_tokens": {
+      "gpt-4o-mini-tts": {
+        "input": 0.6,
+        "estimated_cost_per_minute": 0.015
+      },
+      "gpt-4o-transcribe": {
+        "input": 2.5,
+        "output": 10,
+        "estimated_cost_per_minute": 0.006
+      },
+      "gpt-4o-mini-transcribe": {
+        "input": 1.25,
+        "output": 5,
+        "estimated_cost_per_minute": 0.003
+      }
+    },
+    "audio_tokens": {
+      "gpt-4o-mini-tts": {
+        "output": 12,
+        "estimated_cost_per_minute": 0.015
+      },
+      "gpt-4o-transcribe": {
+        "input": 6,
+        "estimated_cost_per_minute": 0.006
+      },
+      "gpt-4o-mini-transcribe": {
+        "input": 3,
+        "estimated_cost_per_minute": 0.003
       }
     }
   },
@@ -196,6 +324,17 @@
     "text-embedding-ada-002": 0.1
   },
   "image": {
+    "gpt-image-1": {
+      "low-1024-1024": 0.011,
+      "low-1024-1536": 0.016,
+      "low-1536-1024": 0.016,
+      "medium-1024-1024": 0.042,
+      "medium-1024-1536": 0.063,
+      "medium-1536-1024": 0.063,
+      "high-1024-1024": 0.167,
+      "high-1024-1536": 0.25,
+      "high-1536-1024": 0.25
+    },
     "dall-e-3": {
       "standard-1024-1024": 0.04,
       "standard-1024-1792": 0.08,


### PR DESCRIPTION
Add GPT-4.1, GPT-4.1-mini, and GPT-4.1-nano models with input, output,
cachedInput, and batchDiscount pricing details. Introduce new models like
o1-pro, o3, codex-mini-latest, and gpt-image-1 with corresponding pricing.

Expand pricing structure to include flex-processing, image-tokens, and
fine-tuning categories with updated training and token costs for new
model variants. Adjust web-search pricing tiers for GPT-4.1 and mini
models to align with updated cost structure.

Add transcription_speech pricing for text and audio tokens with
estimated costs per minute for various GPT-4o mini and transcribe models.

Include detailed image generation pricing for gpt-image-1 across
multiple resolution and quality tiers.

These changes provide comprehensive pricing updates for new and existing
models, enabling accurate cost estimation and billing for expanded
service offerings.